### PR TITLE
feat: find by office use case administrator

### DIFF
--- a/backend/administrative/src/main/java/com/mh/ga/administrative/controllers/AdministratorController.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/controllers/AdministratorController.java
@@ -3,6 +3,8 @@ package com.mh.ga.administrative.controllers;
 import com.mh.ga.administrative.models.transfers.AdministratorRequest;
 import com.mh.ga.administrative.models.transfers.AdministratorResponse;
 import com.mh.ga.administrative.services.administrator.AdministratorService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +34,14 @@ public class AdministratorController {
     public ResponseEntity<AdministratorResponse> findByDoc(@RequestBody String document) {
         return ResponseEntity.ok(
                 service.findByDoc(document)
+        );
+    }
+
+    @GetMapping("/office")
+    public ResponseEntity<Page<AdministratorResponse>> findByOffice(
+            @RequestParam(defaultValue = "") String officeName, Pageable pageable) {
+        return ResponseEntity.ok(
+                service.findByOffice(officeName, pageable)
         );
     }
 

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/AdministratorRepository.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/AdministratorRepository.java
@@ -1,6 +1,9 @@
 package com.mh.ga.administrative.repositories;
 
 import com.mh.ga.administrative.models.entities.Administrator;
+import com.mh.ga.administrative.models.enums.Offices;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,5 @@ import java.util.UUID;
 @Repository
 public interface AdministratorRepository extends JpaRepository<Administrator, UUID> {
     Administrator findByDocument(String document);
+    Page<Administrator> findByOffice(Offices office, Pageable pageable);
 }

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/adapter/AdministratorAdapter.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/adapter/AdministratorAdapter.java
@@ -1,9 +1,14 @@
 package com.mh.ga.administrative.repositories.adapter;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 public interface AdministratorAdapter<ENTITY, IDENTITY> {
     ENTITY save(ENTITY entity);
     Optional<ENTITY> findById(IDENTITY id);
     ENTITY findByDocument(String document);
+    Page<ENTITY> findByOffice(String office, Pageable pageable);
+    Page<ENTITY> findAll(Pageable pageable);
 }

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/adapter/impls/AdministratorAdapterImpl.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/repositories/adapter/impls/AdministratorAdapterImpl.java
@@ -1,8 +1,11 @@
 package com.mh.ga.administrative.repositories.adapter.impls;
 
 import com.mh.ga.administrative.models.entities.Administrator;
+import com.mh.ga.administrative.models.enums.Offices;
 import com.mh.ga.administrative.repositories.AdministratorRepository;
 import com.mh.ga.administrative.repositories.adapter.AdministratorAdapter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -25,6 +28,18 @@ public class AdministratorAdapterImpl implements AdministratorAdapter<Administra
 
     @Override public Administrator findByDocument(String document) {
         return repository.findByDocument(document);
+    }
+
+    @Override public Page<Administrator> findByOffice(String office, Pageable pageable) {
+        return repository.findByOffice(
+                Offices.toEnum(office),
+                pageable
+        );
+    }
+
+    @Override
+    public Page<Administrator> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
     }
 
 }

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/AdministratorService.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/AdministratorService.java
@@ -2,6 +2,8 @@ package com.mh.ga.administrative.services.administrator;
 
 import com.mh.ga.administrative.models.transfers.AdministratorRequest;
 import com.mh.ga.administrative.models.transfers.AdministratorResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,14 +12,17 @@ public class AdministratorService {
 
     private final FindByIdAdministrator<String, AdministratorResponse> findById;
     private final FindByDocAdministrator<String, AdministratorResponse> findByDoc;
+    private final FindByOfficeAdministrator<String, Page<AdministratorResponse>> findByOffice;
     private final SaveAdministrator<AdministratorRequest, AdministratorResponse> save;
 
     public AdministratorService(
             FindByIdAdministrator<String, AdministratorResponse> findById,
             FindByDocAdministrator<String, AdministratorResponse> findByDoc,
+            FindByOfficeAdministrator<String, Page<AdministratorResponse>> findByOffice,
             SaveAdministrator<AdministratorRequest, AdministratorResponse> save) {
         this.findById = findById;
         this.findByDoc = findByDoc;
+        this.findByOffice = findByOffice;
         this.save = save;
     }
 
@@ -29,6 +34,11 @@ public class AdministratorService {
     @Transactional(readOnly = true)
     public AdministratorResponse findByDoc(String document) {
         return findByDoc.execute(document);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdministratorResponse> findByOffice(String officeName, Pageable pageable) {
+        return findByOffice.execute(officeName, pageable);
     }
 
     @Transactional

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/FindByOfficeAdministrator.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/FindByOfficeAdministrator.java
@@ -1,0 +1,7 @@
+package com.mh.ga.administrative.services.administrator;
+
+import org.springframework.data.domain.Pageable;
+
+public interface FindByOfficeAdministrator<REQUEST, RESPONSE> {
+    RESPONSE execute(REQUEST request, Pageable pageable);
+}

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/configs/AdministratorConfig.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/configs/AdministratorConfig.java
@@ -8,12 +8,15 @@ import com.mh.ga.administrative.repositories.adapter.AdministratorAdapter;
 import com.mh.ga.administrative.repositories.adapter.impls.AdministratorAdapterImpl;
 import com.mh.ga.administrative.services.administrator.FindByDocAdministrator;
 import com.mh.ga.administrative.services.administrator.FindByIdAdministrator;
+import com.mh.ga.administrative.services.administrator.FindByOfficeAdministrator;
 import com.mh.ga.administrative.services.administrator.SaveAdministrator;
 import com.mh.ga.administrative.services.administrator.impls.FindByDocAdministratorImpl;
 import com.mh.ga.administrative.services.administrator.impls.FindByIdAdministratorImpl;
+import com.mh.ga.administrative.services.administrator.impls.FindByOfficeAdministratorImpl;
 import com.mh.ga.administrative.services.administrator.impls.SaveAdministratorImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
 
 import java.util.UUID;
 
@@ -33,6 +36,11 @@ public class AdministratorConfig {
     @Bean public FindByDocAdministrator<String, AdministratorResponse> findByDoc(
             AdministratorAdapter<Administrator, UUID> adapter) {
         return new FindByDocAdministratorImpl(adapter);
+    }
+
+    @Bean public FindByOfficeAdministrator<String, Page<AdministratorResponse>> findByOffice(
+            AdministratorAdapter<Administrator, UUID> adapter) {
+        return new FindByOfficeAdministratorImpl(adapter);
     }
 
     @Bean public SaveAdministrator<AdministratorRequest, AdministratorResponse> save(

--- a/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/impls/FindByOfficeAdministratorImpl.java
+++ b/backend/administrative/src/main/java/com/mh/ga/administrative/services/administrator/impls/FindByOfficeAdministratorImpl.java
@@ -1,0 +1,48 @@
+package com.mh.ga.administrative.services.administrator.impls;
+
+import com.mh.ga.administrative.models.entities.Administrator;
+import com.mh.ga.administrative.models.transfers.AdministratorResponse;
+import com.mh.ga.administrative.repositories.adapter.AdministratorAdapter;
+import com.mh.ga.administrative.services.administrator.FindByOfficeAdministrator;
+import com.mh.ga.administrative.services.exceptions.ResourceNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public class FindByOfficeAdministratorImpl
+        implements FindByOfficeAdministrator<String, Page<AdministratorResponse>> {
+
+    private final AdministratorAdapter<Administrator, UUID> adapter;
+
+    public FindByOfficeAdministratorImpl(AdministratorAdapter<Administrator, UUID> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override public Page<AdministratorResponse> execute(String officeName, Pageable pageable) {
+        Page<Administrator> found;
+
+        if (officeName == null) {
+            throw new IllegalArgumentException(
+                    "Operation not valid on the requested system"
+            );
+        }
+
+        found = officeName.isBlank() ?
+                adapter.findAll(pageable) :
+                adapter.findByOffice(officeName, pageable)
+        ;
+
+        if (found.isEmpty()) {
+            throw new ResourceNotFoundException(
+                    "Administrator not found with the requested Office name informated"
+            );
+        }
+
+        return new PageImpl<>(
+                found.stream().map(AdministratorResponse::toResponse).toList()
+        );
+    }
+
+}

--- a/backend/administrative/src/test/java/com/mh/ga/administrative/services/administrator/impls/FindByOfficeAdministratorImplTest.java
+++ b/backend/administrative/src/test/java/com/mh/ga/administrative/services/administrator/impls/FindByOfficeAdministratorImplTest.java
@@ -1,0 +1,109 @@
+package com.mh.ga.administrative.services.administrator.impls;
+
+import com.mh.ga.administrative.models.entities.Administrator;
+import com.mh.ga.administrative.models.factories.AdministratorFactory;
+import com.mh.ga.administrative.models.transfers.AdministratorResponse;
+import com.mh.ga.administrative.repositories.adapter.AdministratorAdapter;
+import com.mh.ga.administrative.services.exceptions.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static net.bytebuddy.matcher.ElementMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class FindByOfficeAdministratorImplTest {
+
+    private AdministratorAdapter<Administrator, UUID> adapter;
+    private FindByOfficeAdministratorImpl useCase;
+
+    private Pageable pageable;
+
+    private String existingOffice, nonExistingOffice;
+    private Administrator entity;
+    private AdministratorResponse response;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        adapter = mock(AdministratorAdapter.class);
+        useCase = new FindByOfficeAdministratorImpl(adapter);
+
+        UUID id = UUID.randomUUID();
+        pageable = PageRequest.of(0, 12);
+
+        entity = AdministratorFactory.createEntityByID(id);
+        response = AdministratorFactory.createResponseByID(id.toString());
+
+        existingOffice = entity.getOffice().toString();
+        nonExistingOffice = "non_existing_office";
+
+        when(adapter.findByOffice(existingOffice, pageable)).thenReturn(new PageImpl<>(List.of(entity)));
+        when(adapter.findByOffice(nonExistingOffice, pageable)).thenReturn(new PageImpl<>(List.of()));
+    }
+
+    @Test
+    @DisplayName("FindByOffice should return found page when was successfull found")
+    void findByOffice_shouldReturnFoundPage_whenWasSuccessfullFound() {
+        Page<AdministratorResponse> result = useCase.execute(existingOffice, pageable);
+
+        verify(adapter).findByOffice(any(), any());
+
+        assertFalse(result.isEmpty());
+        assertTrue(result.toList().contains(response));
+    }
+
+    @Test
+    @DisplayName("FindByOffice should return page result FindAll when Office name is blank")
+    void findByOffice_shouldReturnPageResultFindAll_whenOfficeNameIsBlank() {
+        when(adapter.findAll(pageable)).thenReturn(new PageImpl<>(List.of(entity)));
+
+        Page<AdministratorResponse> result = useCase.execute("", pageable);
+
+        verify(adapter).findAll(any());
+
+        assertFalse(result.isEmpty());
+        assertTrue(result.toList().contains(response));
+    }
+
+    @Test
+    @DisplayName("FindByOffice should throw IllegalArgumentException when Office name is null")
+    void findByOffice_shouldThrowIllegalArgumentException_whenOfficeNameIsNull() {
+        String expectedErrorMessage = "Operation not valid on the requested system";
+
+        Throwable result = assertThrows(
+                IllegalArgumentException.class,
+                () -> useCase.execute(null, pageable)
+        );
+
+        assertEquals(expectedErrorMessage, result.getMessage());
+    }
+
+    @Test
+    @DisplayName("FindByOffice should throw ResourceNotFoundException when resource not found by office")
+    void findByOffice_shouldReturnResourceNotFoundException_whenResourceNotFoundByOffice() {
+        String expectedErrorMessage = "Administrator not found with the requested Office name informated";
+
+        Throwable result = assertThrows(
+                ResourceNotFoundException.class,
+                () -> useCase.execute(nonExistingOffice, pageable)
+        );
+
+        assertEquals(expectedErrorMessage, result.getMessage());
+    }
+
+}


### PR DESCRIPTION
Use case find administrator by their office name creates, if not specified, results in all administrators, both paginated results